### PR TITLE
Fix syntax for creating users and granting permissions

### DIFF
--- a/en/for-django.md
+++ b/en/for-django.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "sql" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "sql" >}}
 
     ```sql
-    GRANT ALL ON DATABASE django TO <username>;
+    GRANT ALL ON django.* TO <username>;
     ```
 
 ## Step 3. Set virtual environments and initialize the project

--- a/en/for-go-sql-driver-mysql.md
+++ b/en/for-go-sql-driver-mysql.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE go_mysql TO <username>;
+    GRANT ALL ON go_mysql.* TO <username>;
     ```
 
 ## Step 3. Get and run the application code

--- a/en/for-gorm.md
+++ b/en/for-gorm.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE gorm TO <username>;
+    GRANT ALL ON gorm.* TO <username>;
     ```
 
 ## Step 3. Get and run the application code

--- a/en/for-hibernate-orm.md
+++ b/en/for-hibernate-orm.md
@@ -51,7 +51,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code later.
@@ -61,7 +61,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE bank TO <username>;
+    GRANT ALL ON bank.* TO <username>;
     ```
 
 ## Step 3. Get and run the application code

--- a/en/for-laravel.md
+++ b/en/for-laravel.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE laravel_demo TO <username>;
+    GRANT ALL ON laravel_demo.* TO <username>;
     ```
 
 ## Step 3. Prepare your Laravel project

--- a/en/for-python-mysql-connector.md
+++ b/en/for-python-mysql-connector.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE tidb_example TO <username>;
+    GRANT ALL ON tidb_example.* TO <username>;
     ```
 
 ## Step 3. Set virtual environments and initialize the project

--- a/en/for-sqlalchemy.md
+++ b/en/for-sqlalchemy.md
@@ -43,7 +43,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    CREATE USER <username> WITH PASSWORD <password>;
+    CREATE USER <username> IDENTIFIED BY <password>;
     ```
 
     Take note of the username and password. You will use them in your application code when initializing the project.
@@ -53,7 +53,7 @@ The above command starts a temporary and single-node cluster with mock TiKV. The
     {{< copyable "" >}}
 
     ```sql
-    GRANT ALL ON DATABASE test_sqlalchemy TO <username>;
+    GRANT ALL ON test_sqlalchemy.* TO <username>;
     ```
 
 ## Step 3. Set virtual environments and initialize the project


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The syntax in the document to create users and grant permissions is invalid.
